### PR TITLE
Deprecate in favor of babel-brunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Adds [React](http://facebook.github.io/react) support to [brunch](http://brunch.io)
 by automatically compiling `*.jsx` files.
 
+**DEPRECATED:** Please use [`babel-brunch`](https://github.com/babel/babel-brunch) instead.
+
 ### Optional
 
 Example `config.coffee`:


### PR DESCRIPTION
On June 12, 2015, the React team announced the deprecation of react-tools and JSTransform in favor of Babel.

https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html

As a new `brunch` user, it wasn't immediate obvious which plugin to use for my React project—`react-brunch` or `babel-brunch`. I doubt I'm the only one. Given the momentum within the React community, I propose this plugin become deprecated in favor of [`babel-brunch`](https://github.com/babel/babel-brunch).